### PR TITLE
fix: log critic value diagnostics separately

### DIFF
--- a/dreamer4/dreamer4.py
+++ b/dreamer4/dreamer4.py
@@ -6461,6 +6461,7 @@ class DynamicsWorldModel(Module):
         use_delight_gating = None,
         delight_temperature = None,
         normalize_advantages = None,
+        return_diagnostics = False,
         eps = 1e-6
     ):
         use_delight_gating = default(use_delight_gating, self.use_delight_gating)
@@ -6835,6 +6836,45 @@ class DynamicsWorldModel(Module):
             returns = returns[:, :-1]
             old_values = old_values[:, :-1]
 
+        diagnostics = None
+
+        if return_diagnostics:
+            value_mask = mask
+
+            if value_mask.shape[1] != returns.shape[1]:
+                value_mask = value_mask[:, :returns.shape[1]]
+
+            masked_returns = returns[value_mask]
+            masked_values = values[value_mask]
+
+            diagnostics = {
+                'critic/gae_return_mean': masked_returns.mean().detach(),
+                'critic/gae_return_min': masked_returns.min().detach(),
+                'critic/gae_return_max': masked_returns.max().detach(),
+                'critic/value_mean': masked_values.mean().detach(),
+                'critic/value_min': masked_values.min().detach(),
+                'critic/value_max': masked_values.max().detach(),
+                'critic/value_abs_error': (masked_values - masked_returns).abs().mean().detach()
+            }
+
+            value_support = getattr(self.value_encoder, 'bin_values', None)
+
+            if exists(value_support):
+                min_value, max_value = value_support[0], value_support[-1]
+            else:
+                value_support = getattr(getattr(self.value_encoder, 'loss', None), 'support', None)
+
+                if exists(value_support):
+                    min_value, max_value = value_support[0], value_support[-1]
+                else:
+                    min_value, max_value = self.value_encoder.reward_range
+                    min_value = tensor(min_value, device = returns.device)
+                    max_value = tensor(max_value, device = returns.device)
+
+            diagnostics['critic/value_target_saturation_frac'] = (
+                (masked_returns < min_value) | (masked_returns > max_value)
+            ).float().mean().detach()
+
         return_bins = self.value_encoder(returns)
 
         value_bins, return_bins = tuple(rearrange(t, 'b t l -> b l t') for t in (value_bins, return_bins))
@@ -6862,6 +6902,9 @@ class DynamicsWorldModel(Module):
 
             value_optim.step()
             value_optim.zero_grad()
+
+        if return_diagnostics:
+            return total_policy_loss, value_loss, diagnostics
 
         return total_policy_loss, value_loss
 

--- a/dreamer4/dreamer4.py
+++ b/dreamer4/dreamer4.py
@@ -6851,6 +6851,7 @@ class DynamicsWorldModel(Module):
                 'critic/gae_return_mean': masked_returns.mean().detach(),
                 'critic/gae_return_min': masked_returns.min().detach(),
                 'critic/gae_return_max': masked_returns.max().detach(),
+                'critic/gae_return_abs_max': masked_returns.abs().max().detach(),
                 'critic/value_mean': masked_values.mean().detach(),
                 'critic/value_min': masked_values.min().detach(),
                 'critic/value_max': masked_values.max().detach(),

--- a/tests/test_dreamer.py
+++ b/tests/test_dreamer.py
@@ -350,6 +350,7 @@ def test_action_with_world_model():
         'critic/gae_return_mean',
         'critic/gae_return_min',
         'critic/gae_return_max',
+        'critic/gae_return_abs_max',
         'critic/value_mean',
         'critic/value_min',
         'critic/value_max',

--- a/tests/test_dreamer.py
+++ b/tests/test_dreamer.py
@@ -344,7 +344,18 @@ def test_action_with_world_model():
 
     # take a reinforcement learning step
 
-    actor_loss, critic_loss = dynamics.learn_from_experience(gen)
+    actor_loss, critic_loss, diagnostics = dynamics.learn_from_experience(gen, return_diagnostics = True)
+
+    assert {
+        'critic/gae_return_mean',
+        'critic/gae_return_min',
+        'critic/gae_return_max',
+        'critic/value_mean',
+        'critic/value_min',
+        'critic/value_max',
+        'critic/value_abs_error',
+        'critic/value_target_saturation_frac'
+    } <= diagnostics.keys()
 
     actor_loss.backward(retain_graph = True)
     critic_loss.backward()

--- a/train_halfcheetah_imagination_rl.py
+++ b/train_halfcheetah_imagination_rl.py
@@ -823,11 +823,12 @@ def train_agent_in_imagination(
             if objective == "pmpo" and exists(policy_prior):
                 dream = attach_policy_prior_unembeds(dream, policy_prior)
 
-        policy_loss, value_loss = world_model.learn_from_experience(
+        policy_loss, value_loss, value_diagnostics = world_model.learn_from_experience(
             dream,
             only_learn_policy_value_heads = True,
             objective = objective,
             use_delight_gating = use_delight_gating,
+            return_diagnostics = True,
         )
 
         loss = policy_loss + value_loss
@@ -841,7 +842,7 @@ def train_agent_in_imagination(
         if objective == "pmpo" and exists(policy_prior):
             agent_metrics.update(agent_prior_kl_metrics(world_model, dream, policy_prior))
 
-        dream_return = dream.episode_return.mean().item() if exists(dream.episode_return) else 0.
+        raw_reward_sum_mean = dream.episode_return.mean().item() if exists(dream.episode_return) else 0.
         dream_len = dream.lens.float().mean().item() if exists(dream.lens) else horizon
         action_std = dream.actions.continuous.std().item() if exists(dream.actions) and exists(dream.actions.continuous) else 0.
 
@@ -849,7 +850,7 @@ def train_agent_in_imagination(
             "imagination/loss": loss.item(),
             "imagination/policy_loss": policy_loss.item(),
             "imagination/value_loss": value_loss.item(),
-            "imagination/dream_return": dream_return,
+            "imagination/raw_reward_sum_mean": raw_reward_sum_mean,
             "imagination/dream_length": dream_len,
             "imagination/action_std": action_std,
             "imagination/prompt_length": prompt_length if exists(prompts) else 0,
@@ -862,12 +863,16 @@ def train_agent_in_imagination(
             "imagination/prior_kl_max": agent_metrics.get("prior_kl_max", torch.tensor(0.)).item(),
         }
         last_metrics.update({
+            key: value.item()
+            for key, value in value_diagnostics.items()
+        })
+        last_metrics.update({
             f"imagination/{key}": value
             for key, value in grad_metrics.items()
         })
 
         log_scalars(writer, last_metrics, global_step)
-        pbar.set_postfix(return_ = f"{dream_return:.1f}", loss = f"{loss.item():.3f}")
+        pbar.set_postfix(raw_reward = f"{raw_reward_sum_mean:.1f}", loss = f"{loss.item():.3f}")
         global_step += 1
 
     return global_step, last_metrics
@@ -1239,7 +1244,7 @@ def main(
         if wm_metrics:
             postfix["wm"] = f"{wm_metrics['world_model/loss']:.2f}"
         if imagination_metrics:
-            postfix["dream"] = f"{imagination_metrics['imagination/dream_return']:.1f}"
+            postfix["dream"] = f"{imagination_metrics['imagination/raw_reward_sum_mean']:.1f}"
         pbar.set_postfix(postfix)
 
         if checkpoint_every > 0 and divisible_by(loop + 1, checkpoint_every):


### PR DESCRIPTION
Refs #14.

Summary:
- add opt-in critic/value diagnostics from `learn_from_experience`
- log raw imagined reward sums as `imagination/raw_reward_sum_mean`
- log GAE returns, absolute max GAE target magnitude, value predictions, absolute error, and value target saturation under `critic/*`
- use `critic/gae_return_abs_max` to compare target magnitude against the critic support, e.g. values above `640` indicate targets outside a `+-640` range

Tests:
- `python -m py_compile dreamer4/dreamer4.py tests/test_dreamer.py`
- `uv run --with imageio pytest -q tests/test_dreamer.py::test_action_with_world_model`