### PR TITLE
fix: use symlog hl-gauss support

### DIFF
--- a/dreamer4/dreamer4.py
+++ b/dreamer4/dreamer4.py
@@ -1000,6 +1000,12 @@ class SEM(Module):
 
 # rewards
 
+def symlog(t):
+    return t.sign() * (t.abs() + 1.).log()
+
+def symexp(t):
+    return t.sign() * (t.abs().exp() - 1.)
+
 class SymExpTwoHot(Module):
     def __init__(
         self,
@@ -1104,23 +1110,34 @@ class HLGaussRewardEncoder(Module):
         eps = 1e-10,
         clamp_to_range = True,
         min_max_value_on_bin_center = False,
+        use_symlog = False,
+        decode_symlog_expected_raw = True,
         learned_embedding = False,
         dim_embed = None,
     ):
         super().__init__()
 
         min_value, max_value = reward_range
+        transform = symlog if use_symlog else None
+        inverse_transform = symexp if use_symlog else None
+        loss_min_value = symexp(tensor(min_value)) if use_symlog else min_value
+        loss_max_value = symexp(tensor(max_value)) if use_symlog else max_value
 
         self.reward_range = reward_range
+        self.use_symlog = use_symlog
+        self.clamp_to_range = clamp_to_range
+        self.decode_symlog_expected_raw = decode_symlog_expected_raw
         self.loss = HLGaussLoss(
-            min_value,
-            max_value,
+            loss_min_value,
+            loss_max_value,
             num_bins,
             sigma = sigma,
             sigma_to_bin_ratio = sigma_to_bin_ratio,
             eps = eps,
             clamp_to_range = clamp_to_range,
             min_max_value_on_bin_center = min_max_value_on_bin_center,
+            transform = transform,
+            inverse_transform = inverse_transform,
         )
 
         self.num_bins = self.loss.num_bins
@@ -1146,6 +1163,19 @@ class HLGaussRewardEncoder(Module):
         logits,
         normalize = True
     ):
+        if self.use_symlog and self.decode_symlog_expected_raw:
+            probs = logits.softmax(dim = -1) if normalize else logits
+            support = symexp(self.loss.centers)
+
+            if self.num_bins % 2 == 1:
+                mid = self.num_bins // 2
+                left_probs, zero_probs, right_probs = probs[..., :mid], probs[..., mid:mid + 1], probs[..., mid + 1:]
+                left_support, zero_support, right_support = support[:mid], support[mid:mid + 1], support[mid + 1:]
+                paired = (left_probs * left_support).flip(-1) + right_probs * right_support
+                return (zero_probs * zero_support).sum(dim = -1) + paired.sum(dim = -1)
+
+            return einsum(probs, support, '... l, l -> ...')
+
         if normalize:
             return self.loss.transform_from_logits(logits)
 
@@ -1157,6 +1187,20 @@ class HLGaussRewardEncoder(Module):
     ):
         if values.numel() == 0:
             return values.new_empty((*values.shape, self.num_bins))
+
+        if self.use_symlog:
+            values = symlog(values)
+
+            if self.clamp_to_range:
+                min_value, max_value = self.reward_range
+                values = values.clamp(min = min_value, max = max_value)
+
+            support = self.loss.support
+            support = support.view(*((1,) * values.ndim), -1)
+            cdf_evals = torch.erf((support - values.unsqueeze(-1)) / self.loss.sigma_times_sqrt_two)
+            z = cdf_evals[..., -1] - cdf_evals[..., 0]
+            probs = cdf_evals[..., 1:] - cdf_evals[..., :-1]
+            return probs / z.clamp(min = self.loss.eps).unsqueeze(-1)
 
         return self.loss.transform_to_probs(values)
 
@@ -6863,14 +6907,23 @@ class DynamicsWorldModel(Module):
             if exists(value_support):
                 min_value, max_value = value_support[0], value_support[-1]
             else:
-                value_support = getattr(getattr(self.value_encoder, 'loss', None), 'support', None)
+                value_loss = getattr(self.value_encoder, 'loss', None)
+                value_support = getattr(value_loss, 'centers', None)
+                value_support = default(value_support, getattr(value_loss, 'support', None))
 
                 if exists(value_support):
                     min_value, max_value = value_support[0], value_support[-1]
+                    inverse_transform = getattr(value_loss, 'inverse_transform', None)
+
+                    if exists(inverse_transform):
+                        min_value, max_value = inverse_transform(min_value), inverse_transform(max_value)
                 else:
                     min_value, max_value = self.value_encoder.reward_range
                     min_value = tensor(min_value, device = returns.device)
                     max_value = tensor(max_value, device = returns.device)
+
+                    if getattr(self.value_encoder, 'use_symlog', False):
+                        min_value, max_value = symexp(min_value), symexp(max_value)
 
             diagnostics['critic/value_target_saturation_frac'] = (
                 (masked_returns < min_value) | (masked_returns > max_value)

--- a/dreamer4/dreamer4.py
+++ b/dreamer4/dreamer4.py
@@ -1006,6 +1006,19 @@ def symlog(t):
 def symexp(t):
     return t.sign() * (t.abs().exp() - 1.)
 
+def decode_expected_scalar_from_probs(probs, support):
+    if support.shape[-1] % 2 == 1:
+        mid = support.shape[-1] // 2
+        left_probs, zero_probs, right_probs = probs[..., :mid], probs[..., mid:mid + 1], probs[..., mid + 1:]
+        left_support, zero_support, right_support = support[:mid], support[mid:mid + 1], support[mid + 1:]
+        paired = (left_probs * left_support).flip(-1) + right_probs * right_support
+        return (zero_probs * zero_support).sum(dim = -1) + paired.sum(dim = -1)
+
+    return einsum(probs, support, '... l, l -> ...')
+
+def decode_symlog_expected_raw_from_probs(probs, centers):
+    return decode_expected_scalar_from_probs(probs, symexp(centers))
+
 class SymExpTwoHot(Module):
     def __init__(
         self,
@@ -1165,16 +1178,7 @@ class HLGaussRewardEncoder(Module):
     ):
         if self.use_symlog and self.decode_symlog_expected_raw:
             probs = logits.softmax(dim = -1) if normalize else logits
-            support = symexp(self.loss.centers)
-
-            if self.num_bins % 2 == 1:
-                mid = self.num_bins // 2
-                left_probs, zero_probs, right_probs = probs[..., :mid], probs[..., mid:mid + 1], probs[..., mid + 1:]
-                left_support, zero_support, right_support = support[:mid], support[mid:mid + 1], support[mid + 1:]
-                paired = (left_probs * left_support).flip(-1) + right_probs * right_support
-                return (zero_probs * zero_support).sum(dim = -1) + paired.sum(dim = -1)
-
-            return einsum(probs, support, '... l, l -> ...')
+            return decode_symlog_expected_raw_from_probs(probs, self.loss.centers)
 
         if normalize:
             return self.loss.transform_from_logits(logits)

--- a/dreamer4/dreamer4.py
+++ b/dreamer4/dreamer4.py
@@ -1948,7 +1948,9 @@ def get_attend_fn(
         block_mask = create_block_mask(block_mask_fn, B = None, H = None, Q_LEN = seq_len, KV_LEN = k_seq_len)
 
         score_mod = score_mod_softclamp(softclamp_value)
-        attend_fn = partial(flex_attention, block_mask = block_mask, score_mod = score_mod, enable_gqa = True)
+
+        def attend_fn(q, k, v, causal = False):
+            return flex_attention(q, k, v, block_mask = block_mask, score_mod = score_mod, enable_gqa = True)
     else:
         # naive pathway
 

--- a/tests/test_train_halfcheetah_imagination_rl.py
+++ b/tests/test_train_halfcheetah_imagination_rl.py
@@ -60,3 +60,55 @@ def test_main_forwards_custom_attention_values_to_world_model():
 
     assert isinstance(kwargs["attn_dim_head"], ast.Name)
     assert kwargs["attn_dim_head"].id == "attn_dim_head"
+
+
+def test_main_uses_symlog_hl_gauss_reward_and_return_ranges():
+    main_fn = get_main_function()
+
+    reward_range_assign = next(
+        node
+        for node in ast.walk(main_fn)
+        if isinstance(node, ast.Assign)
+        and any(isinstance(target, ast.Name) and target.id == "reward_range" for target in node.targets)
+    )
+
+    assert ast.literal_eval(reward_range_assign.value) == (-3.0, 3.0)
+
+    value_range_assign = next(
+        node
+        for node in ast.walk(main_fn)
+        if isinstance(node, ast.Assign)
+        and any(isinstance(target, ast.Name) and target.id == "value_range" for target in node.targets)
+    )
+
+    assert ast.literal_eval(value_range_assign.value) == (-9.90353755128617, 9.90353755128617)
+
+    world_model_call = next(
+        node.value.func.value
+        for node in ast.walk(main_fn)
+        if isinstance(node, ast.Assign)
+        and any(isinstance(target, ast.Name) and target.id == "world_model" for target in node.targets)
+        and isinstance(node.value, ast.Call)
+        and isinstance(node.value.func, ast.Attribute)
+        and node.value.func.attr == "to"
+        and isinstance(node.value.func.value, ast.Call)
+        and isinstance(node.value.func.value.func, ast.Name)
+        and node.value.func.value.func.id == "DynamicsWorldModel"
+    )
+
+    kwargs = keyword_map(world_model_call)
+    reward_kwargs = keyword_map(kwargs["reward_encoder_kwargs"])
+    value_kwargs = keyword_map(kwargs["value_encoder_kwargs"])
+
+    assert isinstance(reward_kwargs["reward_range"], ast.Name)
+    assert reward_kwargs["reward_range"].id == "reward_range"
+    assert ast.literal_eval(reward_kwargs["sigma_to_bin_ratio"]) == 0.75
+    assert ast.literal_eval(reward_kwargs["min_max_value_on_bin_center"]) is True
+    assert ast.literal_eval(reward_kwargs["use_symlog"]) is True
+
+    assert isinstance(value_kwargs["reward_range"], ast.Name)
+    assert value_kwargs["reward_range"].id == "value_range"
+    assert ast.literal_eval(value_kwargs["num_bins"]) == 511
+    assert ast.literal_eval(value_kwargs["sigma_to_bin_ratio"]) == 0.75
+    assert ast.literal_eval(value_kwargs["min_max_value_on_bin_center"]) is True
+    assert ast.literal_eval(value_kwargs["use_symlog"]) is True

--- a/tests/test_train_halfcheetah_imagination_rl.py
+++ b/tests/test_train_halfcheetah_imagination_rl.py
@@ -72,7 +72,7 @@ def test_main_uses_symlog_hl_gauss_reward_and_return_ranges():
         and any(isinstance(target, ast.Name) and target.id == "reward_range" for target in node.targets)
     )
 
-    assert ast.literal_eval(reward_range_assign.value) == (-3.0, 3.0)
+    assert ast.literal_eval(reward_range_assign.value) == (-4.0, 4.0)
 
     value_range_assign = next(
         node

--- a/tests/test_train_halfcheetah_imagination_rl.py
+++ b/tests/test_train_halfcheetah_imagination_rl.py
@@ -81,7 +81,7 @@ def test_main_uses_symlog_hl_gauss_reward_and_return_ranges():
         and any(isinstance(target, ast.Name) and target.id == "value_range" for target in node.targets)
     )
 
-    assert ast.literal_eval(value_range_assign.value) == (-9.90353755128617, 9.90353755128617)
+    assert ast.literal_eval(value_range_assign.value) == (-10.0, 10.0)
 
     world_model_call = next(
         node.value.func.value
@@ -102,13 +102,14 @@ def test_main_uses_symlog_hl_gauss_reward_and_return_ranges():
 
     assert isinstance(reward_kwargs["reward_range"], ast.Name)
     assert reward_kwargs["reward_range"].id == "reward_range"
+    assert ast.literal_eval(reward_kwargs["num_bins"]) == 51
     assert ast.literal_eval(reward_kwargs["sigma_to_bin_ratio"]) == 0.75
     assert ast.literal_eval(reward_kwargs["min_max_value_on_bin_center"]) is True
     assert ast.literal_eval(reward_kwargs["use_symlog"]) is True
 
     assert isinstance(value_kwargs["reward_range"], ast.Name)
     assert value_kwargs["reward_range"].id == "value_range"
-    assert ast.literal_eval(value_kwargs["num_bins"]) == 511
+    assert ast.literal_eval(value_kwargs["num_bins"]) == 51
     assert ast.literal_eval(value_kwargs["sigma_to_bin_ratio"]) == 0.75
     assert ast.literal_eval(value_kwargs["min_max_value_on_bin_center"]) is True
     assert ast.literal_eval(value_kwargs["use_symlog"]) is True

--- a/train_halfcheetah_imagination_rl.py
+++ b/train_halfcheetah_imagination_rl.py
@@ -1037,7 +1037,7 @@ def main(
     )
 
     reward_range = (-3., 3.)
-    value_range = (-9.90353755128617, 9.90353755128617)
+    value_range = (-10., 10.)
 
     world_model = DynamicsWorldModel(
         dim = model_dim,
@@ -1054,8 +1054,8 @@ def main(
         continuous_dist_type = "beta",
         continuous_target_action_range = (-1., 1.),
         reward_encoder_type = reward_encoder_type,
-        reward_encoder_kwargs = dict(reward_range = reward_range, sigma_to_bin_ratio = 0.75, min_max_value_on_bin_center = True, use_symlog = True),
-        value_encoder_kwargs = dict(reward_range = value_range, num_bins = 511, sigma_to_bin_ratio = 0.75, min_max_value_on_bin_center = True, use_symlog = True),
+        reward_encoder_kwargs = dict(reward_range = reward_range, num_bins = 51, sigma_to_bin_ratio = 0.75, min_max_value_on_bin_center = True, use_symlog = True),
+        value_encoder_kwargs = dict(reward_range = value_range, num_bins = 51, sigma_to_bin_ratio = 0.75, min_max_value_on_bin_center = True, use_symlog = True),
         predict_terminals = True,
         continuous_action_loss_weight = 0.,
         discrete_action_loss_weight = 0.,

--- a/train_halfcheetah_imagination_rl.py
+++ b/train_halfcheetah_imagination_rl.py
@@ -712,6 +712,7 @@ def train_world_model(
             terminals = exp.terminals,
             continuous_actions = exp.actions.continuous if exists(exp.actions) else None,
             lens = exp.lens,
+            latent_has_view_dim = True,
             return_all_losses = True,
             update_loss_ema = True,
         )

--- a/train_halfcheetah_imagination_rl.py
+++ b/train_halfcheetah_imagination_rl.py
@@ -1035,8 +1035,8 @@ def main(
         "this script expects the native policy target range to match the env action range [-1, 1]"
     )
 
-    reward_range = (-20., 20.)
-    value_range = tuple(bound * imagination_horizon for bound in reward_range)
+    reward_range = (-3., 3.)
+    value_range = (-9.90353755128617, 9.90353755128617)
 
     world_model = DynamicsWorldModel(
         dim = model_dim,
@@ -1053,8 +1053,8 @@ def main(
         continuous_dist_type = "beta",
         continuous_target_action_range = (-1., 1.),
         reward_encoder_type = reward_encoder_type,
-        reward_encoder_kwargs = dict(reward_range = reward_range),
-        value_encoder_kwargs = dict(reward_range = value_range),
+        reward_encoder_kwargs = dict(reward_range = reward_range, sigma_to_bin_ratio = 0.75, min_max_value_on_bin_center = True, use_symlog = True),
+        value_encoder_kwargs = dict(reward_range = value_range, num_bins = 511, sigma_to_bin_ratio = 0.75, min_max_value_on_bin_center = True, use_symlog = True),
         predict_terminals = True,
         continuous_action_loss_weight = 0.,
         discrete_action_loss_weight = 0.,

--- a/train_halfcheetah_imagination_rl.py
+++ b/train_halfcheetah_imagination_rl.py
@@ -1036,7 +1036,7 @@ def main(
         "this script expects the native policy target range to match the env action range [-1, 1]"
     )
 
-    reward_range = (-3., 3.)
+    reward_range = (-4., 4.)
     value_range = (-10., 10.)
 
     world_model = DynamicsWorldModel(


### PR DESCRIPTION
Use symlog HL-Gauss supports so reward and critic targets do not saturate on HalfCheetah-scale values. Decode symlog buckets as raw expected scalars via named helper functions instead of relying on the package decode path, preserving Dreamer3-style scalar semantics.

Configure HalfCheetah with compact 51-bin reward/value buckets, widening per-step reward support while keeping critic support near the expected late-training return scale. Also keep replay latents marked as already view-qualified during world-model replay training and tolerate the local flex-attention API.

Closes #42

Tests: `uv run pytest tests/test_train_halfcheetah_imagination_rl.py`; `python -m py_compile dreamer4/dreamer4.py train_halfcheetah_imagination_rl.py tests/test_train_halfcheetah_imagination_rl.py`.