### PR TITLE
perf: eliminate compile stalls with static-shape generation and compile-by-default on CUDA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,4 @@ __marimo__/
 # Tokenizer training
 results_mnist_tokenizer/
 checkpoints_mnist_tokenizer/
+checkpoints_halfcheetah_imagination/

--- a/README.md
+++ b/README.md
@@ -174,6 +174,11 @@ Shout out to [@CarsonBurke](https://github.com/CarsonBurke) for this [contributi
 $ uv run train_halfcheetah_imagination_rl.py
 ```
 
+CUDA runs compile the world-model loss, imagination rollout, and imagination
+learning paths with static shapes by default. Pass `--compile=False` to run
+eagerly, or `--compile_mode=max-autotune` to trade additional startup time for
+kernel autotuning.
+
 ## Toy Snake World Model
 
 You can play the ground truth Toy Snake environment in the browser with:

--- a/benchmark_halfcheetah_compile.py
+++ b/benchmark_halfcheetah_compile.py
@@ -135,8 +135,9 @@ def benchmark_common_kwargs(
             tokenizer_batch_size = min(int(common_kwargs["tokenizer_batch_size"]), 16),
         )
     else:
-        # the replay grows loop by loop, so batches larger than one rollout's episode count
-        # change shape across loops and force compiled arms to recompile mid-run
+        # Keep the performance preset on full, non-repeated batches. The training
+        # path can repeat short batches for static compilation, but benchmarking
+        # duplicated episodes would distort throughput comparisons.
 
         max_static_batch = max(benchmark_num_envs, 1)
         world_model_batch_size = int(common_kwargs["world_model_batch_size"])
@@ -144,8 +145,8 @@ def benchmark_common_kwargs(
 
         if max(world_model_batch_size, imagination_batch_size) > max_static_batch:
             print(
-                f"benchmark: clamping batch sizes to {max_static_batch} to keep compiled shapes "
-                "static across loops (raise --benchmark_num_envs for larger batches)"
+                f"benchmark: clamping batch sizes to {max_static_batch} so the initial replay "
+                "provides full batches (raise --benchmark_num_envs for larger batches)"
             )
 
         benchmark_kwargs.update(

--- a/compile_runtime.py
+++ b/compile_runtime.py
@@ -170,12 +170,14 @@ class ImaginationGenerateRollout(nn.Module):
         generate_steps: int,
         store_old_action_unembeds: bool,
         use_time_cache: bool,
+        preallocate_outputs: bool,
     ):
         super().__init__()
         self.world_model = world_model
         self.generate_steps = generate_steps
         self.store_old_action_unembeds = store_old_action_unembeds
         self.use_time_cache = use_time_cache
+        self.preallocate_outputs = preallocate_outputs
 
     def forward(
         self,
@@ -199,6 +201,7 @@ class ImaginationGenerateRollout(nn.Module):
             use_time_cache = self.use_time_cache,
             store_agent_embed = True,
             store_old_action_unembeds = self.store_old_action_unembeds,
+            preallocate_outputs = self.preallocate_outputs,
             prompt_latents = prompt_latents,
             prompt_proprio = prompt_proprio,
             prompt_discrete_actions = prompt_discrete_actions,
@@ -350,8 +353,8 @@ def maybe_compile_and_time(
     effective_compile_mode = compile_mode
 
     if enabled and compile_mode_uses_cuda_graphs(compile_mode) and not compile_cudagraphs:
-        # CUDA Graph capture is unsafe for these autograd loss wrappers: AOTAutograd
-        # keeps forward intermediates live for backward, and graph replay can overwrite them.
+        # AOTAutograd keeps forward intermediates live for backward, and CUDA
+        # Graph replay can overwrite them before compiled loss wrappers finish.
         effective_compile_mode = "max-autotune-no-cudagraphs" if compile_mode == "max-autotune" else "default"
 
     timing = CallTiming(
@@ -391,6 +394,7 @@ def build_compile_runtime(
     compile_mode: str | None,
     compile_fullgraph: bool,
     compile_dynamic: bool | None,
+    compile_generate_cudagraphs: bool,
     track_compile_performance: bool,
     imagination_generate_steps: int,
     imagination_use_time_cache: bool,
@@ -416,13 +420,16 @@ def build_compile_runtime(
     world_model_loss_timing = timing if track_compile_performance else None
     timings.append(timing)
 
+    generate_rollout_module = ImaginationGenerateRollout(
+        world_model,
+        generate_steps = imagination_generate_steps,
+        store_old_action_unembeds = store_old_action_unembeds,
+        use_time_cache = imagination_use_time_cache,
+        preallocate_outputs = compile_generate,
+    )
+
     generate_rollout, timing = maybe_compile_and_time(
-        ImaginationGenerateRollout(
-            world_model,
-            generate_steps = imagination_generate_steps,
-            store_old_action_unembeds = store_old_action_unembeds,
-            use_time_cache = imagination_use_time_cache,
-        ),
+        generate_rollout_module,
         name = "imagination_generate",
         enabled = compile_generate,
         track_timing = track_compile_performance,
@@ -431,7 +438,7 @@ def build_compile_runtime(
         compile_mode = compile_mode,
         compile_fullgraph = compile_fullgraph,
         compile_dynamic = compile_dynamic,
-        compile_cudagraphs = True,
+        compile_cudagraphs = compile_generate_cudagraphs,
     )
     generate_rollout_timing = timing if track_compile_performance else None
     generate_uses_cuda_graphs = timing.cuda_graphs

--- a/dreamer4/dreamer4.py
+++ b/dreamer4/dreamer4.py
@@ -7138,19 +7138,22 @@ class DynamicsWorldModel(Module):
         )
         generated_time = max(time_steps - prompt_time, 0)
 
+        # when preallocating, every accumulator becomes a growing view over a full (b, time_steps, ...) buffer,
+        # so appends are in-place writes and output shapes stay static for compiled generation
+
+        def preallocate_sequence(values):
+            buffer = empty((batch_size, time_steps, *values.shape[2:]), device = self.device, dtype = values.dtype)
+            buffer[:, :prompt_time] = values
+            return buffer, buffer[:, :prompt_time]
+
         preallocated_latents = preallocated_latents_context_noise = None
         preallocated_proprio = preallocated_proprio_context_noise = None
+        preallocated_rewards = None
+        preallocated_discrete_actions = preallocated_continuous_actions = None
 
         if use_preallocated_outputs:
-            preallocated_latents = empty((batch_size, time_steps, self.num_video_views, *latent_shape), device = self.device, dtype = latents.dtype)
-            preallocated_latents_context_noise = torch.empty_like(preallocated_latents)
-
-            if prompt_time > 0:
-                preallocated_latents[:, :prompt_time] = latents
-                preallocated_latents_context_noise[:, :prompt_time] = past_latents_context_noise
-
-            latents = preallocated_latents[:, :prompt_time]
-            past_latents_context_noise = preallocated_latents_context_noise[:, :prompt_time]
+            preallocated_latents, latents = preallocate_sequence(latents)
+            preallocated_latents_context_noise, past_latents_context_noise = preallocate_sequence(past_latents_context_noise)
 
         # proprio
 
@@ -7163,15 +7166,8 @@ class DynamicsWorldModel(Module):
             past_proprio_context_noise = proprio.clone()
 
             if use_preallocated_outputs:
-                preallocated_proprio = empty((batch_size, time_steps, self.dim_proprio), device = self.device, dtype = proprio.dtype)
-                preallocated_proprio_context_noise = torch.empty_like(preallocated_proprio)
-
-                if prompt_time > 0:
-                    preallocated_proprio[:, :prompt_time] = proprio
-                    preallocated_proprio_context_noise[:, :prompt_time] = past_proprio_context_noise
-
-                proprio = preallocated_proprio[:, :prompt_time]
-                past_proprio_context_noise = preallocated_proprio_context_noise[:, :prompt_time]
+                preallocated_proprio, proprio = preallocate_sequence(proprio)
+                preallocated_proprio_context_noise, past_proprio_context_noise = preallocate_sequence(past_proprio_context_noise)
 
         # actions
 
@@ -7179,36 +7175,29 @@ class DynamicsWorldModel(Module):
 
         decoded_discrete_actions = prompt_discrete_actions
         decoded_continuous_actions = prompt_continuous_actions
-        decoded_discrete_action_time = None
-        decoded_continuous_action_time = None
 
         if return_agent_actions:
             num_discrete = self.action_embedder.num_discrete_action_types
             num_continuous = self.action_embedder.num_continuous_action_types
 
             if use_preallocated_outputs:
-                if num_discrete > 0:
-                    decoded_discrete_actions = zeros((batch_size, time_steps, num_discrete), device = self.device, dtype = torch.long)
-                    decoded_discrete_action_time = prompt_time
+                def preallocate_actions(prompt_actions, num_actions, dtype):
+                    if num_actions == 0:
+                        return None, None
 
-                    if exists(prompt_discrete_actions):
-                        discrete_prompt_time = min(prompt_discrete_actions.shape[1], prompt_time)
-                        decoded_discrete_actions[:, :discrete_prompt_time] = prompt_discrete_actions[:, :discrete_prompt_time]
-                        decoded_discrete_action_time = discrete_prompt_time
-                else:
-                    decoded_discrete_actions = None
+                    buffer = zeros((batch_size, time_steps, num_actions), device = self.device, dtype = dtype)
+                    action_time = prompt_time
 
-                if num_continuous > 0:
-                    continuous_dtype = prompt_continuous_actions.dtype if exists(prompt_continuous_actions) else torch.float
-                    decoded_continuous_actions = zeros((batch_size, time_steps, num_continuous), device = self.device, dtype = continuous_dtype)
-                    decoded_continuous_action_time = prompt_time
+                    if exists(prompt_actions):
+                        action_time = min(prompt_actions.shape[1], prompt_time)
+                        buffer[:, :action_time] = prompt_actions[:, :action_time]
 
-                    if exists(prompt_continuous_actions):
-                        continuous_prompt_time = min(prompt_continuous_actions.shape[1], prompt_time)
-                        decoded_continuous_actions[:, :continuous_prompt_time] = prompt_continuous_actions[:, :continuous_prompt_time]
-                        decoded_continuous_action_time = continuous_prompt_time
-                else:
-                    decoded_continuous_actions = None
+                    return buffer, buffer[:, :action_time]
+
+                continuous_dtype = prompt_continuous_actions.dtype if exists(prompt_continuous_actions) else torch.float
+
+                preallocated_discrete_actions, decoded_discrete_actions = preallocate_actions(prompt_discrete_actions, num_discrete, torch.long)
+                preallocated_continuous_actions, decoded_continuous_actions = preallocate_actions(prompt_continuous_actions, num_continuous, continuous_dtype)
             else:
                 if exists(decoded_discrete_actions):
                     decoded_discrete_actions = decoded_discrete_actions.clone()
@@ -7236,16 +7225,7 @@ class DynamicsWorldModel(Module):
         decoded_rewards = None
 
         if return_rewards_per_frame:
-            if use_preallocated_outputs:
-                decoded_rewards = zeros((batch_size, time_steps), device = self.device, dtype = torch.float32)
-
-                if exists(prompt_rewards):
-                    if prompt_rewards.shape[1] == prompt_time - 1:
-                        decoded_rewards[:, 1:prompt_time] = prompt_rewards
-                    else:
-                        reward_prompt_time = min(prompt_rewards.shape[1], time_steps)
-                        decoded_rewards[:, :reward_prompt_time] = prompt_rewards[:, :reward_prompt_time]
-            elif exists(prompt_rewards):
+            if exists(prompt_rewards):
                 decoded_rewards = prompt_rewards.clone()
 
                 # if prompt rewards has 1 less timestep than latents (e.g. from standard RL episodes where the first state has no reward)
@@ -7255,12 +7235,19 @@ class DynamicsWorldModel(Module):
             else:
                 decoded_rewards = zeros((batch_size, prompt_time), device = self.device, dtype = torch.float32)
 
-        def grow_sequence(preallocated, current, value):
             if use_preallocated_outputs:
-                preallocated[:, curr_time_steps:curr_time_steps + 1] = value
-                return preallocated[:, :curr_time_steps + 1]
+                preallocated_rewards = zeros((batch_size, time_steps), device = self.device, dtype = torch.float32)
+                reward_prompt_time = min(decoded_rewards.shape[1], time_steps)
+                preallocated_rewards[:, :reward_prompt_time] = decoded_rewards[:, :reward_prompt_time]
+                decoded_rewards = preallocated_rewards[:, :prompt_time]
 
-            return cat((current, value), dim = 1)
+        def grow_sequence(preallocated, current, value):
+            if use_preallocated_outputs and exists(preallocated) and exists(value):
+                next_time = current.shape[1]
+                preallocated[:, next_time:next_time + 1] = value
+                return preallocated[:, :next_time + 1]
+
+            return safe_cat((current, value), dim = 1)
 
         def store_generated(t, value, index):
             if use_preallocated_outputs:
@@ -7271,13 +7258,6 @@ class DynamicsWorldModel(Module):
                 return t
 
             return safe_cat((t, value), dim = 1)
-
-        def store_timestep(t, value, index):
-            if use_preallocated_outputs:
-                t[:, index:index + 1] = value
-                return t
-
-            return cat((t, value), dim = 1)
 
         # maybe return terminals
 
@@ -7346,29 +7326,23 @@ class DynamicsWorldModel(Module):
 
                 # action conditioning
 
-                valid_discrete_action_time = default(decoded_discrete_action_time, curr_time_steps)
-
                 curr_discrete = None
-                if exists(decoded_discrete_actions) and valid_discrete_action_time > 0:
-                    curr_discrete = decoded_discrete_actions[:, :valid_discrete_action_time]
+                if exists(decoded_discrete_actions) and not is_empty(decoded_discrete_actions):
+                    curr_discrete = decoded_discrete_actions[:, :curr_time_steps]
                     curr_discrete = pad_right_at_dim_to(curr_discrete, curr_time_steps, dim = 1)
 
-                valid_continuous_action_time = default(decoded_continuous_action_time, curr_time_steps)
-
                 curr_continuous = None
-                if exists(decoded_continuous_actions) and valid_continuous_action_time > 0:
-                    curr_continuous = decoded_continuous_actions[:, :valid_continuous_action_time]
+                if exists(decoded_continuous_actions) and not is_empty(decoded_continuous_actions):
+                    curr_continuous = decoded_continuous_actions[:, :curr_time_steps]
                     curr_continuous = pad_right_at_dim_to(curr_continuous, curr_time_steps, dim = 1)
 
                 # forward for prediction
-
-                curr_rewards = decoded_rewards[:, :curr_time_steps] if use_preallocated_outputs and exists(decoded_rewards) else decoded_rewards
 
                 pred, (embeds, next_time_cache) = self.forward(
                     latents = noised_latent_with_context,
                     signal_levels = signal_levels_with_context,
                     step_sizes = step_size,
-                    rewards = curr_rewards,
+                    rewards = decoded_rewards,
                     tasks = tasks,
                     latent_gene_ids = latent_gene_ids,
                     discrete_actions = curr_discrete,
@@ -7439,7 +7413,7 @@ class DynamicsWorldModel(Module):
                 reward_logits = self.to_latent_state_reward_pred(pooled_latents)
                 pred_reward = self.reward_encoder.bins_to_scalar_value(reward_logits)
 
-                decoded_rewards = store_timestep(decoded_rewards, pred_reward, curr_time_steps)
+                decoded_rewards = grow_sequence(preallocated_rewards, decoded_rewards, pred_reward)
 
             # maybe predict terminals
 
@@ -7483,17 +7457,8 @@ class DynamicsWorldModel(Module):
                     continuous_temperature = continuous_temperature
                 )
 
-                if use_preallocated_outputs:
-                    if exists(sampled_discrete_actions):
-                        decoded_discrete_actions[:, decoded_discrete_action_time:decoded_discrete_action_time + 1] = sampled_discrete_actions
-                        decoded_discrete_action_time += 1
-
-                    if exists(sampled_continuous_actions):
-                        decoded_continuous_actions[:, decoded_continuous_action_time:decoded_continuous_action_time + 1] = sampled_continuous_actions
-                        decoded_continuous_action_time += 1
-                else:
-                    decoded_discrete_actions = safe_cat((decoded_discrete_actions, sampled_discrete_actions), dim = 1)
-                    decoded_continuous_actions = safe_cat((decoded_continuous_actions, sampled_continuous_actions), dim = 1)
+                decoded_discrete_actions = grow_sequence(preallocated_discrete_actions, decoded_discrete_actions, sampled_discrete_actions)
+                decoded_continuous_actions = grow_sequence(preallocated_continuous_actions, decoded_continuous_actions, sampled_continuous_actions)
 
                 if return_log_probs_and_values:
                     discrete_log_probs, continuous_log_probs = self.action_embedder.log_probs(
@@ -7598,16 +7563,6 @@ class DynamicsWorldModel(Module):
         if exists(acc_policy_embed) and store_old_action_unembeds:
             old_action_unembeds = Actions(*self.action_embedder.unembed(acc_policy_embed, pred_head_index = 0))
 
-        decoded_discrete_actions_out = decoded_discrete_actions
-        decoded_continuous_actions_out = decoded_continuous_actions
-
-        if use_preallocated_outputs and return_agent_actions:
-            if exists(decoded_discrete_actions_out):
-                decoded_discrete_actions_out = decoded_discrete_actions_out[:, :decoded_discrete_action_time]
-
-            if exists(decoded_continuous_actions_out):
-                decoded_continuous_actions_out = decoded_continuous_actions_out[:, :decoded_continuous_action_time]
-
         gen = Experience(
             latents = latents,
             video = video,
@@ -7622,7 +7577,7 @@ class DynamicsWorldModel(Module):
             is_from_world_model = True,
             episode_return = episode_return,
             rewards = decoded_rewards if return_rewards_per_frame else None,
-            actions = Actions(decoded_discrete_actions_out, decoded_continuous_actions_out) if return_agent_actions else None,
+            actions = Actions(decoded_discrete_actions, decoded_continuous_actions) if return_agent_actions else None,
             log_probs = Actions(decoded_discrete_log_probs, decoded_continuous_log_probs) if return_log_probs_and_values else None,
             values = decoded_values if return_log_probs_and_values else None
         )

--- a/dreamer4/dreamer4.py
+++ b/dreamer4/dreamer4.py
@@ -7014,6 +7014,7 @@ class DynamicsWorldModel(Module):
         return_time_cache = False,
         store_agent_embed = True,
         store_old_action_unembeds = True,
+        preallocate_outputs = False,
         prompt: Tensor | None = None,           # (b c t h w) or (b c h w)
         prompt_audio: Tensor | None = None,     # (b c t samples) or (b c samples)
         prompt_state: Tensor | None = None,     # (b t d) or (b d)
@@ -7130,6 +7131,26 @@ class DynamicsWorldModel(Module):
         # prompt related variables
 
         prompt_time = latents.shape[1]
+        use_preallocated_outputs = (
+            preallocate_outputs and
+            time_steps > prompt_time and
+            not (return_terminals and self.predict_terminals)
+        )
+        generated_time = max(time_steps - prompt_time, 0)
+
+        preallocated_latents = preallocated_latents_context_noise = None
+        preallocated_proprio = preallocated_proprio_context_noise = None
+
+        if use_preallocated_outputs:
+            preallocated_latents = empty((batch_size, time_steps, self.num_video_views, *latent_shape), device = self.device, dtype = latents.dtype)
+            preallocated_latents_context_noise = torch.empty_like(preallocated_latents)
+
+            if prompt_time > 0:
+                preallocated_latents[:, :prompt_time] = latents
+                preallocated_latents_context_noise[:, :prompt_time] = past_latents_context_noise
+
+            latents = preallocated_latents[:, :prompt_time]
+            past_latents_context_noise = preallocated_latents_context_noise[:, :prompt_time]
 
         # proprio
 
@@ -7141,26 +7162,63 @@ class DynamicsWorldModel(Module):
 
             past_proprio_context_noise = proprio.clone()
 
+            if use_preallocated_outputs:
+                preallocated_proprio = empty((batch_size, time_steps, self.dim_proprio), device = self.device, dtype = proprio.dtype)
+                preallocated_proprio_context_noise = torch.empty_like(preallocated_proprio)
+
+                if prompt_time > 0:
+                    preallocated_proprio[:, :prompt_time] = proprio
+                    preallocated_proprio_context_noise[:, :prompt_time] = past_proprio_context_noise
+
+                proprio = preallocated_proprio[:, :prompt_time]
+                past_proprio_context_noise = preallocated_proprio_context_noise[:, :prompt_time]
+
         # actions
 
         return_agent_actions |= return_log_probs_and_values
 
         decoded_discrete_actions = prompt_discrete_actions
         decoded_continuous_actions = prompt_continuous_actions
+        decoded_discrete_action_time = None
+        decoded_continuous_action_time = None
 
         if return_agent_actions:
             num_discrete = self.action_embedder.num_discrete_action_types
             num_continuous = self.action_embedder.num_continuous_action_types
 
-            if exists(decoded_discrete_actions):
-                decoded_discrete_actions = decoded_discrete_actions.clone()
-            elif num_discrete > 0:
-                decoded_discrete_actions = zeros((batch_size, prompt_time, num_discrete), device = self.device, dtype = torch.long)
+            if use_preallocated_outputs:
+                if num_discrete > 0:
+                    decoded_discrete_actions = zeros((batch_size, time_steps, num_discrete), device = self.device, dtype = torch.long)
+                    decoded_discrete_action_time = prompt_time
 
-            if exists(decoded_continuous_actions):
-                decoded_continuous_actions = decoded_continuous_actions.clone()
-            elif num_continuous > 0:
-                decoded_continuous_actions = zeros((batch_size, prompt_time, num_continuous), device = self.device, dtype = torch.float)
+                    if exists(prompt_discrete_actions):
+                        discrete_prompt_time = min(prompt_discrete_actions.shape[1], prompt_time)
+                        decoded_discrete_actions[:, :discrete_prompt_time] = prompt_discrete_actions[:, :discrete_prompt_time]
+                        decoded_discrete_action_time = discrete_prompt_time
+                else:
+                    decoded_discrete_actions = None
+
+                if num_continuous > 0:
+                    continuous_dtype = prompt_continuous_actions.dtype if exists(prompt_continuous_actions) else torch.float
+                    decoded_continuous_actions = zeros((batch_size, time_steps, num_continuous), device = self.device, dtype = continuous_dtype)
+                    decoded_continuous_action_time = prompt_time
+
+                    if exists(prompt_continuous_actions):
+                        continuous_prompt_time = min(prompt_continuous_actions.shape[1], prompt_time)
+                        decoded_continuous_actions[:, :continuous_prompt_time] = prompt_continuous_actions[:, :continuous_prompt_time]
+                        decoded_continuous_action_time = continuous_prompt_time
+                else:
+                    decoded_continuous_actions = None
+            else:
+                if exists(decoded_discrete_actions):
+                    decoded_discrete_actions = decoded_discrete_actions.clone()
+                elif num_discrete > 0:
+                    decoded_discrete_actions = zeros((batch_size, prompt_time, num_discrete), device = self.device, dtype = torch.long)
+
+                if exists(decoded_continuous_actions):
+                    decoded_continuous_actions = decoded_continuous_actions.clone()
+                elif num_continuous > 0:
+                    decoded_continuous_actions = zeros((batch_size, prompt_time, num_continuous), device = self.device, dtype = torch.float)
 
         # policy optimization related
 
@@ -7178,7 +7236,16 @@ class DynamicsWorldModel(Module):
         decoded_rewards = None
 
         if return_rewards_per_frame:
-            if exists(prompt_rewards):
+            if use_preallocated_outputs:
+                decoded_rewards = zeros((batch_size, time_steps), device = self.device, dtype = torch.float32)
+
+                if exists(prompt_rewards):
+                    if prompt_rewards.shape[1] == prompt_time - 1:
+                        decoded_rewards[:, 1:prompt_time] = prompt_rewards
+                    else:
+                        reward_prompt_time = min(prompt_rewards.shape[1], time_steps)
+                        decoded_rewards[:, :reward_prompt_time] = prompt_rewards[:, :reward_prompt_time]
+            elif exists(prompt_rewards):
                 decoded_rewards = prompt_rewards.clone()
 
                 # if prompt rewards has 1 less timestep than latents (e.g. from standard RL episodes where the first state has no reward)
@@ -7187,6 +7254,30 @@ class DynamicsWorldModel(Module):
                     decoded_rewards = pad_left_at_dim(decoded_rewards, 1, value = 0., dim = 1)
             else:
                 decoded_rewards = zeros((batch_size, prompt_time), device = self.device, dtype = torch.float32)
+
+        def grow_sequence(preallocated, current, value):
+            if use_preallocated_outputs:
+                preallocated[:, curr_time_steps:curr_time_steps + 1] = value
+                return preallocated[:, :curr_time_steps + 1]
+
+            return cat((current, value), dim = 1)
+
+        def store_generated(t, value, index):
+            if use_preallocated_outputs:
+                if not exists(t):
+                    t = value.new_empty((batch_size, generated_time, *value.shape[2:]))
+
+                t[:, index:index + 1] = value
+                return t
+
+            return safe_cat((t, value), dim = 1)
+
+        def store_timestep(t, value, index):
+            if use_preallocated_outputs:
+                t[:, index:index + 1] = value
+                return t
+
+            return cat((t, value), dim = 1)
 
         # maybe return terminals
 
@@ -7200,6 +7291,7 @@ class DynamicsWorldModel(Module):
         while latents.shape[1] < time_steps:
 
             curr_time_steps = latents.shape[1]
+            generated_index = curr_time_steps - prompt_time
 
             # determine whether to take an extra step if
             # (1) using time kv cache
@@ -7254,23 +7346,29 @@ class DynamicsWorldModel(Module):
 
                 # action conditioning
 
+                valid_discrete_action_time = default(decoded_discrete_action_time, curr_time_steps)
+
                 curr_discrete = None
-                if exists(decoded_discrete_actions) and not is_empty(decoded_discrete_actions):
-                    curr_discrete = decoded_discrete_actions[:, :curr_time_steps]
+                if exists(decoded_discrete_actions) and valid_discrete_action_time > 0:
+                    curr_discrete = decoded_discrete_actions[:, :valid_discrete_action_time]
                     curr_discrete = pad_right_at_dim_to(curr_discrete, curr_time_steps, dim = 1)
 
+                valid_continuous_action_time = default(decoded_continuous_action_time, curr_time_steps)
+
                 curr_continuous = None
-                if exists(decoded_continuous_actions) and not is_empty(decoded_continuous_actions):
-                    curr_continuous = decoded_continuous_actions[:, :curr_time_steps]
+                if exists(decoded_continuous_actions) and valid_continuous_action_time > 0:
+                    curr_continuous = decoded_continuous_actions[:, :valid_continuous_action_time]
                     curr_continuous = pad_right_at_dim_to(curr_continuous, curr_time_steps, dim = 1)
 
                 # forward for prediction
+
+                curr_rewards = decoded_rewards[:, :curr_time_steps] if use_preallocated_outputs and exists(decoded_rewards) else decoded_rewards
 
                 pred, (embeds, next_time_cache) = self.forward(
                     latents = noised_latent_with_context,
                     signal_levels = signal_levels_with_context,
                     step_sizes = step_size,
-                    rewards = decoded_rewards,
+                    rewards = curr_rewards,
                     tasks = tasks,
                     latent_gene_ids = latent_gene_ids,
                     discrete_actions = curr_discrete,
@@ -7341,7 +7439,7 @@ class DynamicsWorldModel(Module):
                 reward_logits = self.to_latent_state_reward_pred(pooled_latents)
                 pred_reward = self.reward_encoder.bins_to_scalar_value(reward_logits)
 
-                decoded_rewards = cat((decoded_rewards, pred_reward), dim = 1)
+                decoded_rewards = store_timestep(decoded_rewards, pred_reward, curr_time_steps)
 
             # maybe predict terminals
 
@@ -7361,7 +7459,7 @@ class DynamicsWorldModel(Module):
             # maybe store agent embed
 
             if store_agent_embed:
-                acc_agent_embed = safe_cat((acc_agent_embed, one_agent_embed), dim = 1)
+                acc_agent_embed = store_generated(acc_agent_embed, one_agent_embed, generated_index)
 
             # decode the agent actions if needed
 
@@ -7373,7 +7471,7 @@ class DynamicsWorldModel(Module):
                 # maybe store old actions
 
                 if store_old_action_unembeds:
-                    acc_policy_embed = safe_cat((acc_policy_embed, policy_embed), dim = 1)
+                    acc_policy_embed = store_generated(acc_policy_embed, policy_embed, generated_index)
 
                 # sample actions
 
@@ -7385,8 +7483,17 @@ class DynamicsWorldModel(Module):
                     continuous_temperature = continuous_temperature
                 )
 
-                decoded_discrete_actions = safe_cat((decoded_discrete_actions, sampled_discrete_actions), dim = 1)
-                decoded_continuous_actions = safe_cat((decoded_continuous_actions, sampled_continuous_actions), dim = 1)
+                if use_preallocated_outputs:
+                    if exists(sampled_discrete_actions):
+                        decoded_discrete_actions[:, decoded_discrete_action_time:decoded_discrete_action_time + 1] = sampled_discrete_actions
+                        decoded_discrete_action_time += 1
+
+                    if exists(sampled_continuous_actions):
+                        decoded_continuous_actions[:, decoded_continuous_action_time:decoded_continuous_action_time + 1] = sampled_continuous_actions
+                        decoded_continuous_action_time += 1
+                else:
+                    decoded_discrete_actions = safe_cat((decoded_discrete_actions, sampled_discrete_actions), dim = 1)
+                    decoded_continuous_actions = safe_cat((decoded_continuous_actions, sampled_continuous_actions), dim = 1)
 
                 if return_log_probs_and_values:
                     discrete_log_probs, continuous_log_probs = self.action_embedder.log_probs(
@@ -7396,28 +7503,31 @@ class DynamicsWorldModel(Module):
                         continuous_targets = sampled_continuous_actions
                     )
 
-                    decoded_discrete_log_probs = safe_cat((decoded_discrete_log_probs, discrete_log_probs), dim = 1)
-                    decoded_continuous_log_probs = safe_cat((decoded_continuous_log_probs, continuous_log_probs), dim = 1)
+                    if exists(discrete_log_probs):
+                        decoded_discrete_log_probs = store_generated(decoded_discrete_log_probs, discrete_log_probs, generated_index)
+
+                    if exists(continuous_log_probs):
+                        decoded_continuous_log_probs = store_generated(decoded_continuous_log_probs, continuous_log_probs, generated_index)
 
                     value_bins = self.value_head(one_agent_embed)
                     values = self.value_encoder.bins_to_scalar_value(value_bins)
 
-                    decoded_values = safe_cat((decoded_values, values), dim = 1)
+                    decoded_values = store_generated(decoded_values, values, generated_index)
 
             # concat the denoised latent
 
-            latents = cat((latents, denoised_latent), dim = 1)
+            latents = grow_sequence(preallocated_latents, latents, denoised_latent)
 
             # add new fixed context noise for the temporal consistency
 
-            past_latents_context_noise = cat((past_latents_context_noise, randn_like(denoised_latent)), dim = 1)
+            past_latents_context_noise = grow_sequence(preallocated_latents_context_noise, past_latents_context_noise, randn_like(denoised_latent))
 
             # handle proprio
 
             if has_proprio:
-                proprio = cat((proprio, denoised_proprio), dim = 1)
+                proprio = grow_sequence(preallocated_proprio, proprio, denoised_proprio)
 
-                past_proprio_context_noise = cat((past_proprio_context_noise, randn_like(denoised_proprio)), dim = 1)
+                past_proprio_context_noise = grow_sequence(preallocated_proprio_context_noise, past_proprio_context_noise, randn_like(denoised_proprio))
 
             # maybe early break if entirely terminated
 
@@ -7488,6 +7598,16 @@ class DynamicsWorldModel(Module):
         if exists(acc_policy_embed) and store_old_action_unembeds:
             old_action_unembeds = Actions(*self.action_embedder.unembed(acc_policy_embed, pred_head_index = 0))
 
+        decoded_discrete_actions_out = decoded_discrete_actions
+        decoded_continuous_actions_out = decoded_continuous_actions
+
+        if use_preallocated_outputs and return_agent_actions:
+            if exists(decoded_discrete_actions_out):
+                decoded_discrete_actions_out = decoded_discrete_actions_out[:, :decoded_discrete_action_time]
+
+            if exists(decoded_continuous_actions_out):
+                decoded_continuous_actions_out = decoded_continuous_actions_out[:, :decoded_continuous_action_time]
+
         gen = Experience(
             latents = latents,
             video = video,
@@ -7502,7 +7622,7 @@ class DynamicsWorldModel(Module):
             is_from_world_model = True,
             episode_return = episode_return,
             rewards = decoded_rewards if return_rewards_per_frame else None,
-            actions = Actions(decoded_discrete_actions, decoded_continuous_actions) if return_agent_actions else None,
+            actions = Actions(decoded_discrete_actions_out, decoded_continuous_actions_out) if return_agent_actions else None,
             log_probs = Actions(decoded_discrete_log_probs, decoded_continuous_log_probs) if return_log_probs_and_values else None,
             values = decoded_values if return_log_probs_and_values else None
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "fire",
     "hl-gauss-pytorch",
     "h-net-dynamic-chunking>=0.5.12",
+    "imageio",
     "imageio-ffmpeg",
     "loguru",
     "memmap-replay-buffer>=0.1.10",

--- a/tests/test_dreamer.py
+++ b/tests/test_dreamer.py
@@ -1,6 +1,7 @@
 import pytest
 param = pytest.mark.parametrize
 import torch
+from contextlib import nullcontext
 from einops import rearrange
 
 def exists(v):
@@ -360,6 +361,124 @@ def test_action_with_world_model():
 
     actor_loss.backward(retain_graph = True)
     critic_loss.backward()
+
+
+@param('action_kind, has_proprio, use_time_cache, autocast_dtype', (
+    ('continuous', False, False, None),
+    ('discrete', True, True, torch.bfloat16),
+))
+def test_generate_preallocated_outputs_match_eager_contract(action_kind, has_proprio, use_time_cache, autocast_dtype):
+    from dreamer4.dreamer4 import DynamicsWorldModel
+
+    use_continuous_actions = action_kind == 'continuous'
+
+    dynamics = DynamicsWorldModel(
+        dim = 16,
+        dim_latent = 8,
+        max_steps = 8,
+        num_latent_tokens = 2,
+        num_spatial_tokens = 2,
+        depth = 1,
+        time_block_every = 1,
+        dim_proprio = 3 if has_proprio else None,
+        num_discrete_actions = 4 if not use_continuous_actions else 0,
+        num_continuous_actions = 2 if use_continuous_actions else 0,
+        continuous_dist_type = "beta",
+        reward_encoder_kwargs = dict(num_bins = 11),
+        value_encoder_kwargs = dict(num_bins = 11),
+    )
+
+    prompt_latents = torch.randn(2, 2, 2, 8).clamp(-1., 1.)
+    prompt_proprio = torch.randn(2, 2, 3) if has_proprio else None
+    prompt_discrete_actions = torch.randint(0, 4, (2, 1, 1)) if not use_continuous_actions else None
+    prompt_continuous_actions = torch.randn(2, 1, 2).sigmoid() if use_continuous_actions else None
+    prompt_rewards = torch.randn(2, 1)
+
+    generate_kwargs = dict(
+        time_steps = 5,
+        num_steps = 2,
+        batch_size = 2,
+        return_decoded_video = False,
+        return_rewards_per_frame = True,
+        return_agent_actions = True,
+        return_log_probs_and_values = True,
+        return_terminals = False,
+        use_time_cache = use_time_cache,
+        prompt_latents = prompt_latents,
+        prompt_proprio = prompt_proprio,
+        prompt_discrete_actions = prompt_discrete_actions,
+        prompt_continuous_actions = prompt_continuous_actions,
+        prompt_rewards = prompt_rewards,
+    )
+
+    generate_kwargs = {
+        key: value
+        for key, value in generate_kwargs.items()
+        if value is not None
+    }
+
+    def assert_matching_tensor(preallocated_tensor, eager_tensor):
+        assert exists(preallocated_tensor) == exists(eager_tensor)
+
+        if not exists(preallocated_tensor):
+            return
+
+        assert preallocated_tensor.dtype == eager_tensor.dtype
+
+        if preallocated_tensor.is_floating_point():
+            assert torch.allclose(preallocated_tensor, eager_tensor)
+        else:
+            assert torch.equal(preallocated_tensor, eager_tensor)
+
+    def assert_preallocated_matches_eager(**kwargs):
+        autocast = torch.autocast('cpu', dtype = autocast_dtype) if exists(autocast_dtype) else nullcontext()
+
+        with torch.no_grad(), autocast:
+            torch.manual_seed(123)
+            eager = dynamics.generate(**kwargs)
+
+            torch.manual_seed(123)
+            preallocated = dynamics.generate(**kwargs, preallocate_outputs = True)
+
+        for preallocated_tensor, eager_tensor in (
+            (preallocated.latents, eager.latents),
+            (preallocated.proprio, eager.proprio),
+            (preallocated.rewards, eager.rewards),
+            (preallocated.agent_embed, eager.agent_embed),
+            (preallocated.actions.discrete, eager.actions.discrete),
+            (preallocated.actions.continuous, eager.actions.continuous),
+            (preallocated.log_probs.discrete, eager.log_probs.discrete),
+            (preallocated.log_probs.continuous, eager.log_probs.continuous),
+            (preallocated.values, eager.values),
+        ):
+            assert_matching_tensor(preallocated_tensor, eager_tensor)
+
+    assert_preallocated_matches_eager(**generate_kwargs)
+
+    no_prompt_generate_kwargs = dict(generate_kwargs)
+
+    for key in (
+        'prompt_latents',
+        'prompt_proprio',
+        'prompt_discrete_actions',
+        'prompt_continuous_actions',
+        'prompt_rewards',
+    ):
+        no_prompt_generate_kwargs.pop(key, None)
+
+    assert_preallocated_matches_eager(**no_prompt_generate_kwargs)
+
+    no_generate_kwargs = dict(generate_kwargs, time_steps = prompt_latents.shape[1])
+
+    with torch.no_grad():
+        eager = dynamics.generate(**no_generate_kwargs)
+        preallocated = dynamics.generate(**no_generate_kwargs, preallocate_outputs = True)
+
+    assert preallocated.agent_embed is eager.agent_embed is None
+    assert preallocated.values is eager.values is None
+    assert_matching_tensor(preallocated.actions.discrete, eager.actions.discrete)
+    assert_matching_tensor(preallocated.actions.continuous, eager.actions.continuous)
+
 
 def test_action_embedder():
     from dreamer4.dreamer4 import ActionEmbedder

--- a/tests/test_train_halfcheetah_imagination_rl.py
+++ b/tests/test_train_halfcheetah_imagination_rl.py
@@ -15,6 +15,16 @@ def get_main_function():
     raise AssertionError("main() not found")
 
 
+def get_function(name):
+    module = ast.parse(SCRIPT_PATH.read_text())
+
+    for node in module.body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+
+    raise AssertionError(f"{name}() not found")
+
+
 def keyword_map(call):
     return {
         keyword.arg: keyword.value
@@ -35,6 +45,46 @@ def test_main_default_attention_shape_matches_model_dim():
     }
 
     assert default_by_name["attn_heads"] * default_by_name["attn_dim_head"] == default_by_name["model_dim"]
+
+
+def test_main_compiles_all_static_paths_by_default_on_cuda():
+    main_fn = get_main_function()
+
+    arg_names = [arg.arg for arg in main_fn.args.args]
+    defaults = main_fn.args.defaults
+    default_offset = len(arg_names) - len(defaults)
+    default_by_name = {
+        name: ast.literal_eval(default)
+        for name, default in zip(arg_names[default_offset:], defaults)
+    }
+
+    assert default_by_name["compile"] is None
+    assert default_by_name["compile_dynamic"] is False
+
+    assignments = {
+        target.id: ast.unparse(node.value)
+        for node in ast.walk(main_fn)
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Name)
+    }
+
+    assert assignments["compile"] == "device.type == 'cuda'"
+    assert assignments["compile_world_model"] == "compile or compile_world_model"
+    assert assignments["compile_generate"] == "compile or compile_generate"
+    assert assignments["compile_learn"] == "compile or compile_learn"
+    assert assignments["static_compile_shapes"] == "compile_dynamic is False"
+
+    calls = {
+        node.func.id: keyword_map(node)
+        for node in ast.walk(main_fn)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id in ("train_world_model", "train_agent_in_imagination")
+    }
+
+    assert ast.unparse(calls["train_world_model"]["static_batch_shape"]) == "compile_world_model and static_compile_shapes"
+    assert ast.unparse(calls["train_agent_in_imagination"]["static_generate_shape"]) == "compile_generate and static_compile_shapes"
 
 
 def test_main_forwards_custom_attention_values_to_world_model():
@@ -113,3 +163,39 @@ def test_main_uses_symlog_hl_gauss_reward_and_return_ranges():
     assert ast.literal_eval(value_kwargs["sigma_to_bin_ratio"]) == 0.75
     assert ast.literal_eval(value_kwargs["min_max_value_on_bin_center"]) is True
     assert ast.literal_eval(value_kwargs["use_symlog"]) is True
+
+
+def test_static_generate_shape_requires_prompt_windows():
+    train_fn = get_function("train_agent_in_imagination")
+
+    guards = [
+        ast.unparse(node.test)
+        for node in ast.walk(train_fn)
+        if isinstance(node, ast.If)
+        and any(isinstance(child, ast.Raise) for child in node.body)
+    ]
+
+    assert any(
+        "static_generate_shape" in guard
+        and "prompt_length > 0" in guard
+        and "not exists(prompt_iterator)" in guard
+        for guard in guards
+    )
+
+
+def test_static_world_model_shape_repeats_short_batches():
+    train_fn = get_function("train_world_model")
+
+    static_shape_branch = next(
+        node
+        for node in ast.walk(train_fn)
+        if isinstance(node, ast.If)
+        and ast.unparse(node.test) == "static_batch_shape"
+    )
+
+    assert any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "repeat_batch_to_size"
+        for node in ast.walk(static_shape_branch)
+    )

--- a/train_halfcheetah_imagination_rl.py
+++ b/train_halfcheetah_imagination_rl.py
@@ -1005,10 +1005,38 @@ def save_checkpoint(
 
 
 def load_optimizer_state_if_compatible(optimizer: Optimizer, state_dict, name: str):
+    state_backup = {
+        param: dict(state)
+        for param, state in optimizer.state.items()
+    }
+    param_groups_backup = []
+
+    for group in optimizer.param_groups:
+        group_backup = dict(group)
+        group_backup["params"] = list(group["params"])
+        param_groups_backup.append(group_backup)
+
     try:
         optimizer.load_state_dict(state_dict)
+
+        for group in optimizer.param_groups:
+            for param in group["params"]:
+                state = optimizer.state.get(param, {})
+
+                for state_name, value in state.items():
+                    if not torch.is_tensor(value) or value.ndim == 0:
+                        continue
+
+                    if value.shape != param.shape:
+                        raise ValueError(
+                            f"{state_name} has shape {tuple(value.shape)} for parameter shape {tuple(param.shape)}"
+                        )
+
         return True
     except (KeyError, RuntimeError, ValueError) as exc:
+        optimizer.state.clear()
+        optimizer.state.update(state_backup)
+        optimizer.param_groups[:] = param_groups_backup
         print(f"skipping {name} optimizer state: {exc}")
         return False
 

--- a/train_halfcheetah_imagination_rl.py
+++ b/train_halfcheetah_imagination_rl.py
@@ -1002,38 +1002,24 @@ def save_checkpoint(
 
 
 def load_optimizer_state_if_compatible(optimizer: Optimizer, state_dict, name: str):
-    state_backup = {
-        param: dict(state)
-        for param, state in optimizer.state.items()
-    }
-    param_groups_backup = []
-
-    for group in optimizer.param_groups:
-        group_backup = dict(group)
-        group_backup["params"] = list(group["params"])
-        param_groups_backup.append(group_backup)
+    # load_state_dict swaps in freshly built state rather than mutating existing tensors,
+    # so the backup stays valid for restoring after a failed or rejected load
+    backup = optimizer.state_dict()
 
     try:
         optimizer.load_state_dict(state_dict)
 
         for group in optimizer.param_groups:
             for param in group["params"]:
-                state = optimizer.state.get(param, {})
-
-                for state_name, value in state.items():
-                    if not torch.is_tensor(value) or value.ndim == 0:
-                        continue
-
-                    if value.shape != param.shape:
+                for state_name, value in optimizer.state.get(param, {}).items():
+                    if torch.is_tensor(value) and value.ndim > 0 and value.shape != param.shape:
                         raise ValueError(
                             f"{state_name} has shape {tuple(value.shape)} for parameter shape {tuple(param.shape)}"
                         )
 
         return True
     except (KeyError, RuntimeError, ValueError) as exc:
-        optimizer.state.clear()
-        optimizer.state.update(state_backup)
-        optimizer.param_groups[:] = param_groups_backup
+        optimizer.load_state_dict(backup)
         print(f"skipping {name} optimizer state: {exc}")
         return False
 

--- a/train_halfcheetah_imagination_rl.py
+++ b/train_halfcheetah_imagination_rl.py
@@ -824,9 +824,6 @@ def train_agent_in_imagination(
         window_length = prompt_length,
     )
 
-    if static_generate_shape and prompt_length > 0 and prompt_probability != 1.:
-        raise ValueError("static compiled generation requires prompt_probability=1.0 when prompt_length > 0")
-
     prompt_dataloader = DataLoader(
         prompt_dataset,
         batch_size = batch_size,

--- a/train_halfcheetah_imagination_rl.py
+++ b/train_halfcheetah_imagination_rl.py
@@ -1294,8 +1294,11 @@ def main(
     if start_loop == 0:
         shutil.rmtree(memmap_path, ignore_errors=True)
         replay = None
-    else:
+    elif (memmap_path / "metadata.pkl").exists():
         replay = ReplayBuffer.from_folder(memmap_path)
+    else:
+        print(f"replay buffer not found at {memmap_path}; starting a fresh replay buffer from resumed checkpoint")
+        replay = None
 
     wm_step = 0
     imagination_step = 0

--- a/train_halfcheetah_imagination_rl.py
+++ b/train_halfcheetah_imagination_rl.py
@@ -75,6 +75,20 @@ def cycle(dl):
         for data in dl:
             yield data
 
+
+def repeat_batch_to_size(batch, size: int):
+    tensor = next((t for t in batch.values() if torch.is_tensor(t)), None)
+
+    if not exists(tensor) or tensor.shape[0] == size:
+        return batch
+
+    batch_size = tensor.shape[0]
+    assert 0 < batch_size <= size
+
+    indices = torch.arange(size, device = tensor.device) % batch_size
+
+    return tree_map(lambda t: t.index_select(0, indices) if torch.is_tensor(t) else t, batch)
+
 # tokenizer
 
 class ObservationTokenizer(nn.Module):
@@ -681,6 +695,7 @@ def train_world_model(
     steps: int,
     batch_size: int,
     sequence_length: int | None,
+    static_batch_shape: bool,
     max_grad_norm: float,
     global_step: int,
     writer: SummaryWriter | None,
@@ -714,6 +729,9 @@ def train_world_model(
             step_start = perf_counter()
 
         batch = next(dataloader_iter)
+
+        if static_batch_shape:
+            batch = repeat_batch_to_size(batch, batch_size)
 
         exp = Experience.from_buffer_dict(batch)
         exp.lens = batch.get('_lens')
@@ -786,6 +804,7 @@ def train_agent_in_imagination(
     horizon: int,
     prompt_length: int,
     prompt_probability: float,
+    static_generate_shape: bool,
     generate_steps: int,
     max_grad_norm: float,
     objective: Literal["ppo", "pmpo", "spo"],
@@ -805,6 +824,9 @@ def train_agent_in_imagination(
         window_length = prompt_length,
     )
 
+    if static_generate_shape and prompt_length > 0 and prompt_probability != 1.:
+        raise ValueError("static compiled generation requires prompt_probability=1.0 when prompt_length > 0")
+
     prompt_dataloader = DataLoader(
         prompt_dataset,
         batch_size = batch_size,
@@ -814,19 +836,26 @@ def train_agent_in_imagination(
 
     prompt_iterator = cycle(prompt_dataloader) if prompt_length > 0 and len(prompt_dataloader) > 0 else None
 
+    if static_generate_shape and prompt_length > 0 and not exists(prompt_iterator):
+        raise ValueError("static compiled generation requires at least one prompt window")
+
     for _ in pbar:
         if exists(imagination_step_timing):
             synchronize_if_cuda(world_model.device)
             step_start = perf_counter()
 
         with torch.no_grad():
-            use_prompt = random.random() < prompt_probability
+            use_prompt = static_generate_shape or random.random() < prompt_probability
             prompts = None
 
             if use_prompt and exists(prompt_iterator):
                 prompt_batch = next(prompt_iterator)
 
                 prompt_batch = tree_map(lambda t: t.to(world_model.device) if torch.is_tensor(t) else t, prompt_batch)
+
+                if static_generate_shape:
+                    # Keep compiled generation at one batch shape even when the last prompt batch is short.
+                    prompt_batch = repeat_batch_to_size(prompt_batch, batch_size)
 
                 prompts = dict(
                     prompt_latents = prompt_batch.get('latents'),
@@ -1048,14 +1077,15 @@ def main(
     checkpoint_path: str | None = None,
     clear_log_dir = False,
     unique_log_dir = True,
-    compile = False,
+    compile: bool | None = None,
     compile_world_model = False,
     compile_generate = False,
     compile_learn = False,
     compile_backend = "inductor",
     compile_mode: str | None = "reduce-overhead",
     compile_fullgraph = False,
-    compile_dynamic: bool | None = None,
+    compile_dynamic: bool | None = False,
+    compile_generate_cudagraphs = True,
     track_compile_performance = False,
     allow_tf32 = True,
     require_cuda = False,
@@ -1068,6 +1098,9 @@ def main(
     np.random.seed(seed)
 
     device = torch.device("cpu" if cpu or not torch.cuda.is_available() else "cuda")
+
+    if compile is None:
+        compile = device.type == "cuda"
 
     if require_cuda and device.type != "cuda":
         raise RuntimeError("CUDA was required for this run, but no CUDA device is available")
@@ -1204,6 +1237,10 @@ def main(
     compile_world_model = compile or compile_world_model
     compile_generate = compile or compile_generate
     compile_learn = compile or compile_learn
+    static_compile_shapes = compile_dynamic is False
+
+    if compile_generate and static_compile_shapes and imagination_prompt_length > 0 and imagination_prompt_probability != 1.:
+        raise ValueError("compile_generate requires imagination_prompt_probability=1.0 when imagination_prompt_length > 0")
 
     compile_runtime = build_compile_runtime(
         world_model,
@@ -1218,6 +1255,7 @@ def main(
         track_compile_performance = track_compile_performance,
         imagination_generate_steps = imagination_generate_steps,
         imagination_use_time_cache = imagination_use_time_cache,
+        compile_generate_cudagraphs = compile_generate_cudagraphs,
         objective = objective,
         use_delight_gating = use_delight_gating,
         store_old_action_unembeds = objective == "pmpo" and not exists(policy_prior),
@@ -1248,18 +1286,21 @@ def main(
             if enabled
         ]
         print(f"torch.compile enabled for: {', '.join(compiled_paths)}")
-        if device.type == "cuda" and compile_mode_uses_cuda_graphs(compile_mode):
-            cuda_graph_paths = [
-                name
-                for name, enabled in (
-                    ("imagination_generate", compile_generate),
-                )
-                if enabled
-            ]
+        if device.type == "cuda":
+            cuda_graph_paths = [timing.name for timing in compile_runtime.timings if timing.cuda_graphs]
 
             if len(cuda_graph_paths) > 0:
                 print(f"CUDA Graph capture enabled for: {', '.join(cuda_graph_paths)}")
-                print("CUDA Graph capture disabled for autograd training losses")
+            elif compile_mode_uses_cuda_graphs(compile_mode):
+                print("CUDA Graph capture disabled for compiled training paths")
+
+        fallback_paths = [
+            f"{timing.name}:{compile_mode}->{timing.compile_mode}"
+            for timing in compile_runtime.timings
+            if timing.compiled and exists(timing.compile_mode) and timing.compile_mode != compile_mode
+        ]
+        if len(fallback_paths) > 0:
+            print(f"torch.compile mode fallback for: {', '.join(fallback_paths)}")
     if exists(tokenizer_loss):
         print(f"tokenizer pretrain recon loss: {tokenizer_loss:.4f}")
 
@@ -1361,6 +1402,7 @@ def main(
             steps = world_model_train_steps,
             batch_size = world_model_batch_size,
             sequence_length = world_model_train_sequence_length,
+            static_batch_shape = compile_world_model and static_compile_shapes,
             max_grad_norm = max_grad_norm,
             global_step = wm_step,
             writer = writer,
@@ -1384,6 +1426,7 @@ def main(
             horizon = imagination_horizon,
             prompt_length = imagination_prompt_length,
             prompt_probability = imagination_prompt_probability,
+            static_generate_shape = compile_generate and static_compile_shapes,
             generate_steps = imagination_generate_steps,
             max_grad_norm = max_grad_norm,
             objective = objective,


### PR DESCRIPTION
## Summary

- Add an opt-in `preallocate_outputs` path to `DynamicsWorldModel.generate` that writes rollout outputs into preallocated full-length buffers instead of `cat`-growing them each frame, keeping tensor shapes static for `torch.compile` (reduce-overhead / CUDA graphs). Covered by a seed-parity test asserting identical outputs vs the eager path.
- Enable `torch.compile` for the world-model loss, imagination rollout, and imagination learning paths by default on CUDA in the halfcheetah training script, with static compiled shapes: short replay batches are repeated up to the full batch size, prompt windows are pinned to one shape, and a new `compile_generate_cudagraphs` flag controls CUDA Graph capture for generation.
- Revert optimizer state cleanly when a checkpoint's optimizer state is incompatible (including shape validation of loaded state tensors).
- Start a fresh replay buffer instead of crashing when resuming a checkpoint without memmap replay data.
- Declare `imageio` as a direct dependency (used by `dreamer4/env.py`; `imageio-ffmpeg` does not provide it).